### PR TITLE
add lifecycle hooks and debugging support to MCP integration

### DIFF
--- a/python-sdk/src/anchor/integrations/mcp/server.py
+++ b/python-sdk/src/anchor/integrations/mcp/server.py
@@ -86,14 +86,77 @@ class AnchorMCPServer:
         self.agent_id = agent_id
         self.base_server = base_server
 
+    def __repr__(self) -> str:
+        """
+        String representation for debugging.
+
+        Returns:
+            String representation of the wrapper
+        """
+        return (
+            f"AnchorMCPServer("
+            f"agent_id='{self.agent_id}', "
+            f"base_server={self.base_server!r})"
+        )
+
+    def _pre_start_hook(self) -> None:
+        """
+        Hook called before starting the MCP server.
+
+        This is a stub method indicating where pre-start enforcement,
+        policy checks, or initialization logic will be added in future versions.
+
+        Future implementations may:
+        - Validate policies before server start
+        - Initialize audit logging
+        - Set up context management
+        - Verify required configurations
+        """
+        pass
+
+    def _post_start_hook(self) -> None:
+        """
+        Hook called after starting the MCP server.
+
+        This is a stub method indicating where post-start operations
+        will be added in future versions.
+
+        Future implementations may:
+        - Log server start event
+        - Register active server for monitoring
+        - Initialize context tracking
+        - Set up periodic audit checkpoints
+        """
+        pass
+
     def start(self) -> Any:
         """
-        Start the wrapped MCP server.
+        Start the wrapped MCP server with governance hooks.
 
-        Currently delegates directly to the base server.
-        Future versions will add governance hooks.
+        Calls pre-start hook, delegates to base server, then calls post-start hook.
+        Currently hooks are stubs; future versions will add enforcement.
 
         Returns:
             Result from the base server's start method
         """
-        return self.base_server.start()
+        self._pre_start_hook()
+        result = self.base_server.start()
+        self._post_start_hook()
+        return result
+
+    def stop(self) -> Any:
+        """
+        Stop the wrapped MCP server.
+
+        Delegates to the base server's stop method if available.
+        Future versions will add cleanup and audit logging.
+
+        Returns:
+            Result from the base server's stop method, or None if not available
+
+        Note:
+            If base_server doesn't have a stop() method, this returns None.
+        """
+        if hasattr(self.base_server, "stop") and callable(self.base_server.stop):
+            return self.base_server.stop()
+        return None


### PR DESCRIPTION
Add lifecycle hooks and debugging to MCP integration

- Add _pre_start_hook() and _post_start_hook() stubs
- Add stop() with graceful fallback if base server lacks it
- Add __repr__() for easier debugging

Expand tests from 6 to 9

These changes maintain the skeleton design, signal where enforcement and auditing will go, and improve developer experience.

Follows up on #15