### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're providing tools to control what AI agents store and ensure auditability for developers. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] CrewAI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
In  `python-sdk/README.md`, The project uses CrewAI in code but ships no agent-guidance doc (AGENTS.md/CLAUDE.md). This can lead to inconsistencies and confusion for developers using CrewAI within the SDK.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)